### PR TITLE
1 0 0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea/
+.vscode/
 node_modules/

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ JasmineJS matchers for ProtractorJS
 [![Build Status](https://travis-ci.org/Xotabu4/jasmine-protractor-matchers.svg?branch=master)](https://travis-ci.org/Xotabu4/jasmine-protractor-matchers)[![npm version](https://badge.fury.io/js/jasmine-protractor-matchers.svg)](https://badge.fury.io/js/jasmine-protractor-matchers)[![NPM License](https://img.shields.io/npm/l/jasmine-protractor-matchers.svg)](https://travis-ci.org/Xotabu4/jasmine-protractor-matchers)
 
 
-This module adds some matchers that can be useful for those who develop test cases with ProtractorJS
+This module adds some matchers that can be useful for those who develop test cases with ProtractorJS and Jasmine
 
 Supported versions
 ---------------------
@@ -39,7 +39,7 @@ onPrepare: function() {
     });
 ```
 
-But you can also include only in those specs where it needed, just be sure that you are adding matchers before 'it' function: 
+But you can also include matchers only in those specs where it is needed, just ensure that you are adding matchers before 'it' function: 
 
 some_jasmine_spec.js
 ```javascript

--- a/index.js
+++ b/index.js
@@ -1,5 +1,25 @@
 "use strict";
 
+/**
+ * Used to acquire internal browser from element.
+ * Protractor 4.0 has breaking change in this - .ptor_ was renamed to .browser_
+ * In order to provide backward compatibility - trying to detect browser in both places.
+ *
+ * @returns Protractor instance - browser
+ */
+function getElementFinderBrowser(elementFinder) {
+    if (elementFinder.ptor_ == undefined) {
+        if (elementFinder.browser_ == undefined) {
+            throw new Error('Matcher expects to be applied to ElementFinder object, ' +
+                'please make sure that you pass correct object type');
+        } else {
+            return elementFinder.browser_;
+        }
+    } else {
+        return elementFinder.ptor_;
+    }
+}
+
 //noinspection JSCommentMatchesSignature,JSValidateJSDoc
 module.exports = {
     /**
@@ -14,7 +34,7 @@ module.exports = {
      */
     toAppear: function(){
         return {
-            compare: function(actual){
+            compare: function(elementFinder){
                 let message, timeout;
                 if (typeof arguments[1] === 'string') {
                     timeout = 3000;
@@ -23,26 +43,14 @@ module.exports = {
                     timeout = arguments[1] || 3000;
                     message = arguments[2];
                 }
-                let internalBrowser;
-                if (actual.ptor_ == undefined) {
-                    // Protractor 4.0 renamed .ptor_ to .browser_ , adding backward compatibility
-                    if (actual.browser_ == undefined) {
-                        throw new Error('toAppear() expects to be applied to ElementFinder object, ' +
-                            'please make sure that you pass correct object');
-                    } else {
-                        internalBrowser = actual.browser_;
-                    }
-                } else {
-                    internalBrowser = actual.ptor_;
-                }
 
                 let result = {};
-                result.pass = internalBrowser.wait(protractor.ExpectedConditions.visibilityOf(actual), timeout).then(()=>{
-                    result.message = message || "Element "+ actual.parentElementArrayFinder.locator_.toString() +
+                result.pass = getElementFinderBrowser(elementFinder).wait(protractor.ExpectedConditions.visibilityOf(elementFinder), timeout).then(()=>{
+                    result.message = message || "Element "+ elementFinder.parentElementArrayFinder.locator_.toString() +
                         " was expected NOT to be shown in " + timeout + " milliseconds but is visible";
                     return true;
                 }, err => {
-                    result.message = message || "Element " + actual.parentElementArrayFinder.locator_.toString() +
+                    result.message = message || "Element " + elementFinder.parentElementArrayFinder.locator_.toString() +
                         " was expected to be shown in " + timeout + " milliseconds but is NOT visible";
                     return false;
                 });
@@ -55,7 +63,7 @@ module.exports = {
      */
     toDisappear: function(){
         return {
-            compare: function(actual){
+            compare: function(elementFinder){
                 let message, timeout;
                 if (typeof arguments[1] === 'string') {
                     timeout = 3000;
@@ -65,26 +73,13 @@ module.exports = {
                     message = arguments[2];
                 }
 
-                let internalBrowser;
-                if (actual.ptor_ == undefined) {
-                    // Protractor 4.0 renamed .ptor_ to .browser_ , adding backward compatibility
-                    if (actual.browser_ == undefined) {
-                        throw new Error('toDisappear() expects to be applied to ElementFinder object, ' +
-                            'please make sure that you pass correct object');
-                    } else {
-                        internalBrowser = actual.browser_;
-                    }
-                } else {
-                    internalBrowser = actual.ptor_;
-                }
-
                 let result = {};
-                result.pass = internalBrowser.wait(protractor.ExpectedConditions.invisibilityOf(actual), timeout).then(()=>{
-                    result.message = message || "Element "+ actual.parentElementArrayFinder.locator_.toString() +
+                result.pass = getElementFinderBrowser(elementFinder).wait(protractor.ExpectedConditions.invisibilityOf(elementFinder), timeout).then(()=>{
+                    result.message = message || "Element "+ elementFinder.parentElementArrayFinder.locator_.toString() +
                         " was expected to be shown in " + timeout + " milliseconds but is NOT visible";
                     return true;
                 }, err => {
-                    result.message = message || "Element " + actual.parentElementArrayFinder.locator_.toString() +
+                    result.message = message || "Element " + elementFinder.parentElementArrayFinder.locator_.toString() +
                         " was expected NOT to be shown in " + timeout + " milliseconds but is visible";
                     return false;
                 });

--- a/index.js
+++ b/index.js
@@ -36,7 +36,13 @@ function wrapForJasmine(compareFn) {
     return function () {
         return {
             compare: function () {
-                let elementFinder = arguments[0]; //elementfinder always will be first.
+                //elementfinder always will be first.
+                let elementFinder = arguments[0]; 
+                if(!elementFinder) {
+                    throw new Error('Matcher expects to be applied to ElementFinder object,' + 
+                    'but got:' + elementFinder + 'instead');
+                
+                }
                 
                 return compareFn(elementFinder,
                     getElementFinderBrowser(elementFinder),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jasmine-protractor-matchers",
-  "version": "0.2.0",
+  "version": "1.0.0",
   "description": "Collection of additional jasmine matchers, that is useful for those who develop e2e tests using protractor",
   "main": "index.js",
   "scripts": {

--- a/test.js
+++ b/test.js
@@ -1,5 +1,5 @@
-/**
- * Created by xotab on 21.03.2016.
+/*
+ * Created by xotabu4 on 21.03.2016.
  */
 "use strict";
 var Jasmine = require('jasmine');
@@ -45,9 +45,22 @@ describe('Additional matchers: ', function () {
     let toAppear = matchers.toAppear().compare;
     let toDisappear = matchers.toDisappear().compare;
 
+    let matchersFunctions = [toAppear, toDisappear];
+
+   it('Should throw error on attempt call negateCompare', function () {
+        let negativeCompares = [
+            matchers.toAppear().negativeCompare,
+            matchers.toDisappear().negativeCompare,
+        ]
+
+        for (let negMatcher of negativeCompares) {
+            expect(negMatcher).toThrowError('.not() negation is not supported for jasmine-protractor-matchers, use opposite matcher instead');
+        }
+    });
+
     it('Should throw error on attempt to use on object without browser reference', function () {
         var nonElement = {};
-        for (let matcher of [toAppear, toDisappear]) {
+        for (let matcher of matchersFunctions) {
             let wrapp = function () {
                 return matcher(nonElement);
             };
@@ -57,7 +70,7 @@ describe('Additional matchers: ', function () {
 
     it('Should throw error on attempt to use on undefined object', function () {
         var nonElement = undefined;
-        for (let matcher of [toAppear, toDisappear]) {
+        for (let matcher of matchersFunctions) {
             let wrapp = function () {
                 return matcher(nonElement);
             };
@@ -70,7 +83,7 @@ describe('Additional matchers: ', function () {
         var ptor4Element = new Element();
         ptor4Element.ptor_ = undefined;
         ptor4Element.browser_ = new protractorMock();
-        for (let matcher of [toAppear, toDisappear]) {
+        for (let matcher of matchersFunctions) {
             let wrapp = function () {
                 return matcher(ptor4Element);
             };
@@ -82,7 +95,7 @@ describe('Additional matchers: ', function () {
         }
 
         var ptor3Element = new Element();
-        for (let matcher of [toAppear, toDisappear]) {
+        for (let matcher of matchersFunctions) {
             let wrapp = function () {
                 return matcher(ptor3Element);
             };

--- a/test.js
+++ b/test.js
@@ -116,7 +116,7 @@ describe('Additional matchers: ', function () {
             }
             catch (e) {
                 expect(e.message)
-                    .toBe('toAppear() expects to be applied to ElementFinder object, please make sure that you pass correct object');
+                    .toBe('Matcher expects to be applied to ElementFinder object, please make sure that you pass correct object type');
                 done();
             }
         });
@@ -214,7 +214,7 @@ describe('Additional matchers: ', function () {
             }
             catch (e) {
                 expect(e.message)
-                    .toBe('toDisappear() expects to be applied to ElementFinder object, please make sure that you pass correct object');
+                    .toBe('Matcher expects to be applied to ElementFinder object, please make sure that you pass correct object type');
                 done();
             }
         });

--- a/test.js
+++ b/test.js
@@ -47,7 +47,7 @@ describe('Additional matchers: ', function () {
 
     let matchersFunctions = [toAppear, toDisappear];
 
-   it('Should throw error on attempt call negateCompare', function () {
+   it('Should throw error on attempt to call negateCompare', function () {
         let negativeCompares = [
             matchers.toAppear().negativeCompare,
             matchers.toDisappear().negativeCompare,
@@ -58,7 +58,7 @@ describe('Additional matchers: ', function () {
         }
     });
 
-    it('Should throw error on attempt to use on object without browser reference', function () {
+    it('Should throw error on attempt to be used on object without browser reference', function () {
         var nonElement = {};
         for (let matcher of matchersFunctions) {
             let wrapp = function () {
@@ -68,7 +68,7 @@ describe('Additional matchers: ', function () {
         }
     });
 
-    it('Should throw error on attempt to use on undefined object', function () {
+    it('Should throw error on attempt to be used on undefined object', function () {
         var nonElement = undefined;
         for (let matcher of matchersFunctions) {
             let wrapp = function () {
@@ -87,7 +87,7 @@ describe('Additional matchers: ', function () {
             let wrapp = function () {
                 return matcher(ptor4Element);
             };
-            expect(wrapp).not.toThrowError('Matcher expects to be applied to ElementFinder object, please make sure that you pass correct object type');
+            expect(wrapp).not.toThrowError('Matcher is expected to be applied to ElementFinder object, please make sure that you pass correct object type');
             wrapp().pass.then(pass => {
                 expect(pass).toBe(true, 'Expected result.pass to be resolved to true');
 
@@ -99,7 +99,7 @@ describe('Additional matchers: ', function () {
             let wrapp = function () {
                 return matcher(ptor3Element);
             };
-            expect(wrapp).not.toThrowError('Matcher expects to be applied to ElementFinder object, please make sure that you pass correct object type');
+            expect(wrapp).not.toThrowError('Matcher is expected to be applied to ElementFinder object, please make sure that you pass correct object type');
             wrapp().pass.then(pass => {
                 expect(pass).toBe(true, 'Expected result.pass to be resolved to true');
                 done();
@@ -173,7 +173,7 @@ describe('Additional matchers: ', function () {
             });
         });
 
-        it('should reject result.pass if wait was failed', function (done) {
+        it('should reject result.pass if wait has failed', function (done) {
             var element = new Element();
             element.displayed = false;
             element.ptor_.wait = function(EC) {
@@ -257,7 +257,7 @@ describe('Additional matchers: ', function () {
             });
         });
 
-        it('should reject result.pass if wait was failed', function (done) {
+        it('should reject result.pass if wait has failed', function (done) {
             var element = new Element();
             element.displayed = false;
             element.ptor_.wait = function(EC) {

--- a/test.js
+++ b/test.js
@@ -91,17 +91,22 @@ describe('Additional matchers: ', function () {
 
             result.pass.then(pass => {
                 expect(pass).toBe(true, 'Expected result.pass to be resolved to true');
+                expect(result.message).toBe(undefined, 'Expected result.message not to be defined when success');
                 done();
             });
         });
 
-        it('should return result object with default message, if not specified', function (done) {
+        it('should return failed result object with default message, if not specified', function (done) {
             var element = new Element();
+            element.displayed = false;
+            element.ptor_.wait = function(EC) {
+                return Promise.reject();
+            };
             let result = toAppear(element);
 
             result.pass.then(() => {
-                expect(result.message).toBe("Element " + element.parentElementArrayFinder.locator_ +
-                    " was expected NOT to be shown in " + 3000 + " milliseconds but is visible",
+                expect(result.message).toBe("Element " + element.parentElementArrayFinder.locator_.toString() +
+                " was expected to be shown in " + 3000 + " milliseconds but is NOT visible",
                     'Expected message to equal default message');
                 done();
             });
@@ -109,9 +114,13 @@ describe('Additional matchers: ', function () {
 
         it('should be able to return message object with non-default message and timeout.', function (done) {
             var element = new Element();
-            let originalWait = element.ptor_.wait;
+            element.displayed = false;
+            let originalWait = function(EC) {
+                return Promise.reject();
+            };
             element.ptor_.wait = function (EC, timeout) {
                 element.ptor_.timeout = timeout;
+                
                 return originalWait(EC, timeout);
             };
             let result = toAppear(element, 1000, 'test message');
@@ -123,9 +132,11 @@ describe('Additional matchers: ', function () {
             });
         });
 
-        it('should be able to return message object, if only message was provided', function (done) {
+        it('should be able to return failed object with message, if only message was provided', function (done) {
             var element = new Element();
-            let originalWait = element.ptor_.wait;
+            let originalWait = function(EC) {
+                return Promise.reject();
+            };
             element.ptor_.wait = function (EC, timeout) {
                 element.ptor_.timeout = timeout;
                 return originalWait(EC, timeout);
@@ -162,18 +173,24 @@ describe('Additional matchers: ', function () {
             let result = toDisappear(element);
 
             result.pass.then(pass => {
+                expect(result.message).toBe(undefined, 'Expected result.message not to be defined when success');
                 expect(pass).toBe(true, 'Expected result.pass to be resolved to true');
                 done();
             });
         });
 
-        it('should return result object with default message, if not specified', function (done) {
+        it('should return failed result object with default message, if not specified', function (done) {
             var element = new Element();
+            element.displayed = false;
+            element.ptor_.wait = function(EC) {
+                return Promise.reject();
+            };
             let result = toDisappear(element);
 
-            result.pass.then(() => {
-                expect(result.message).toBe("Element " + element.parentElementArrayFinder.locator_ +
-                    " was expected to be shown in " + 3000 + " milliseconds but is NOT visible",
+            result.pass.then((pass) => {
+                expect(pass).toBe(false, 'Expected result.pass to be resolved to false');
+                expect(result.message).toBe("Element " + element.parentElementArrayFinder.locator_.toString() +
+                " was expected NOT to be shown in " + 3000 + " milliseconds but is visible",
                     'Expected message to equal default message');
                 done();
             });
@@ -181,14 +198,17 @@ describe('Additional matchers: ', function () {
 
         it('should be able to return message object with non-default message and timeout.', function (done) {
             var element = new Element();
-            let originalWait = element.ptor_.wait;
+            let originalWait = function(EC) {
+                return Promise.reject();
+            };
             element.ptor_.wait = function (EC, timeout) {
                 element.ptor_.timeout = timeout;
                 return originalWait(EC, timeout);
             };
             let result = toDisappear(element, 1000, 'test message');
 
-            result.pass.then(() => {
+            result.pass.then((pass) => {
+                expect(pass).toBe(false, 'Expected result.pass to be resolved to false');
                 expect(result.message).toBe('test message');
                 expect(element.ptor_.timeout).toBe(1000);
                 done();
@@ -197,14 +217,17 @@ describe('Additional matchers: ', function () {
 
         it('should be able to return message object, if only message was provided', function (done) {
             var element = new Element();
-            let originalWait = element.ptor_.wait;
+            let originalWait = function(EC) {
+                return Promise.reject();
+            };
             element.ptor_.wait = function (EC, timeout) {
                 element.ptor_.timeout = timeout;
                 return originalWait(EC, timeout);
             };
             let result = toDisappear(element, 'test message');
 
-            result.pass.then(() => {
+            result.pass.then((pass) => {
+                expect(pass).toBe(false, 'Expected result.pass to be resolved to false');
                 expect(result.message).toBe('test message');
                 done();
             });

--- a/test.js
+++ b/test.js
@@ -55,6 +55,17 @@ describe('Additional matchers: ', function () {
         }
     });
 
+    it('Should throw error on attempt to use on undefined object', function () {
+        var nonElement = undefined;
+        for (let matcher of [toAppear, toDisappear]) {
+            let wrapp = function () {
+                return matcher(nonElement);
+            };
+            expect(wrapp).toThrowError('Matcher expects to be applied to ElementFinder object,' + 
+                    'but got:' + nonElement + 'instead');
+        }
+    });
+
     it('Should support both: Protractor 3.x .ptor_ and Protractor 4.x .browser_ attributes', function () {
         var ptor4Element = new Element();
         ptor4Element.ptor_ = undefined;

--- a/test.js
+++ b/test.js
@@ -79,7 +79,7 @@ describe('Additional matchers: ', function () {
         }
     });
 
-    it('Should support both: Protractor 3.x .ptor_ and Protractor 4.x .browser_ attributes', function () {
+    it('Should support both: Protractor 3.x .ptor_ and Protractor 4.x .browser_ attributes', function (done) {
         var ptor4Element = new Element();
         ptor4Element.ptor_ = undefined;
         ptor4Element.browser_ = new protractorMock();


### PR DESCRIPTION
- More abstracted code - extracted wrapping to jasmine matcher to separate function.
- Updated code that provides ElementFinder and Browser into comparison function
- Added cleaner error messages in case: undefined passed into expect() , matcher used with .not 
- Updated jsDocs. 
- Added tests for exceptional cases.
